### PR TITLE
Update AsyncAPI docs

### DIFF
--- a/docs/asyncapi.yaml
+++ b/docs/asyncapi.yaml
@@ -87,9 +87,9 @@ components:
     crn:
       type: number
       description: Customer reference Number
-      minimum: 105000000
-      maximum: 999999999
-      example: 123456789
+      minimum: 1050000000
+      maximum: 9999999999
+      example: 1234567890
 
     sbi:
       type: number

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-fd-comms",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Common communications service for Single Front Door",
   "homepage": "https://github.com/DEFRA/fcp-fd-comms",
   "main": "app/index.js",


### PR DESCRIPTION
Update reference to CRN in AsyncAPI docs to be 10 digits instead of 9.
